### PR TITLE
Rewrite README with accurate project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,229 +1,374 @@
-# BoxLang Electron Starter with Vite
+# BoxLang Electron Starter
 
-A modern starter template for building desktop applications with BoxLang, Electron, and Vite.
+A starter template for building cross-platform desktop applications with [BoxLang](https://www.boxlang.io), [Electron](https://www.electronjs.org), [Vite](https://vite.dev), and [Alpine.js](https://alpinejs.dev).
+
+The app embeds a BoxLang MiniServer as a local HTTP server (bound to `127.0.0.1`) and renders it inside an Electron window — giving you a full server-side BoxLang runtime with a native desktop shell.
+
+---
 
 ## Features
 
-- 🚀 **BoxLang** - Modern CFML runtime for server-side logic
-- ⚡ **Vite** - Fast build tool with HMR (Hot Module Replacement)
-- 🖥️ **Electron** - Cross-platform desktop application framework
-- 🎨 **SCSS** - Enhanced CSS with variables, mixins, and more
-- 📦 **Asset Pipeline** - Automatic asset bundling and optimization
-- 🔄 **Live Reload** - Instant feedback during development
-- 📱 **Responsive** - Mobile-first CSS framework included
+- **BoxLang MiniServer** — full server-side runtime embedded in the desktop app, auto-starts and auto-restarts on crash
+- **Electron** — native window, system tray, OS notifications, taskbar integration on Windows/Linux/macOS
+- **Vite** — fast asset pipeline with hot module replacement in development
+- **Alpine.js** — lightweight reactivity for the UI
+- **SCSS** — a ready-made design system with CSS variables, grid, and components
+- **electron-builder** — one-command packaging to DMG (macOS), NSIS installer (Windows), and AppImage (Linux)
+
+---
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| Node.js | 18+ | [nodejs.org](https://nodejs.org) |
+| BoxLang | 1.6.0 | Only needed for development or to package the MiniServer |
+
+> **Packaged app users** do not need BoxLang installed — the MiniServer is bundled inside the app via `npm run package:full`.
+
+---
 
 ## Quick Start
 
-### Prerequisites
-
-- Node.js (v16 or higher)
-- BoxLang runtime
-- BoxLang MiniServer
-
-### Installation
-
-1. Clone or download this starter template
-2. Install dependencies:
-   ```bash
-   npm install
-   ```
-
-### Development
-
-#### Option 1: Automatic (Recommended)
 ```bash
-# Start both Vite dev server and Electron
-npm run dev:electron
-```
+# 1. Install Node dependencies
+npm install
 
-#### Option 2: Manual
-```bash
-# Terminal 1: Start Vite dev server
+# 2. Start development (Vite + Electron together)
 npm run dev
-
-# Terminal 2: Start Electron (after Vite is running)
-npm run start
 ```
 
-#### Option 3: Use the development script
-```bash
-# Make the script executable (first time only)
-chmod +x dev.sh
+`npm run dev` starts the Vite dev server on `http://127.0.0.1:3000` and then launches Electron after a 3-second delay. The BoxLang MiniServer starts automatically on port `59700`.
 
-# Start development
-./dev.sh dev
-```
-
-### Building for Production
-
-```bash
-# Build assets
-npm run build
-
-# Package the application
-npm run package
-
-# Create distributable
-npm run make
-```
+---
 
 ## Project Structure
 
 ```
-├── electron/
-│   └── main.js              # Electron main process
+boxlang-starter-electron/
+├── .electron/                  # Electron main process (Node.js)
+│   ├── Main.js                 # Entry point, window lifecycle, app settings
+│   ├── BoxLang.js              # BoxLang MiniServer process management
+│   ├── TrayMenu.js             # System tray icon and context menu
+│   ├── AppMenu.js              # Native application menu (File/Edit/View/Help)
+│   └── Shortcuts.js            # Global keyboard shortcuts
+├── .miniserver/                # BoxLang MiniServer distribution
+│   ├── Package.bx              # Download/package script (run via npm)
+│   └── bin/                    # MiniServer executables (after packaging)
+├── .boxlang/
+│   └── config/
+│       └── boxlang.json        # BoxLang runtime configuration
+├── includes/
+│   ├── helpers/
+│   │   └── ViteHelper.bx       # Resolves Vite assets in BoxLang templates
+│   ├── icon.iconset/           # PNG icons (16×16 through 1024×1024)
+│   ├── icon.icns               # macOS dock icon
+│   └── icon.ico                # Windows taskbar/installer icon
 ├── resources/
 │   └── assets/
 │       ├── js/
-│       │   ├── app.js       # Main JavaScript entry point
-│       │   └── stores/      # Alpine.js stores
-│       └── scss/
-│           └── app.scss     # Main stylesheet entry point
-├── includes/
-│   └── helpers/
-│       └── ViteHelper.bx    # BoxLang helper for Vite integration
+│       │   ├── app.js          # JavaScript entry point (Alpine.js init)
+│       │   └── stores/
+│       │       └── modal-store.js
+│       ├── scss/
+│       │   └── app.scss        # SCSS entry point
+│       └── fonts/              # Bundled web fonts (Poppins)
 ├── views/
-│   └── loading.html         # Loading screen
-├── Application.bx           # BoxLang application settings
-├── index.bxm               # Main application template
-├── vite.config.js          # Vite configuration
-├── package.json            # Node.js dependencies and scripts
-└── dev.sh                  # Development helper script
+│   └── loading.html            # Loading screen shown while MiniServer starts
+├── Application.bx              # BoxLang application listener (sessions, mappings)
+├── index.bxm                   # Home page template
+├── vite.config.mjs             # Vite configuration
+├── package.json                # Node scripts, dependencies, electron-builder config
+└── .bvmrc                      # BoxLang version pin (1.6.0)
 ```
 
-## Asset Management
+**Generated at build/runtime:**
 
-### JavaScript
+```
+includes/resources/             # Vite build output (hashed CSS, JS, fonts)
+dist/electron/                  # electron-builder output (installers)
+.database/                      # SQLite database (runtime, gitignored)
+```
 
-Place your JavaScript files in `resources/assets/js/`. The main entry point is `app.js`.
+---
+
+## Development
+
+### Start everything
+
+```bash
+npm run dev
+```
+
+Runs Vite (`http://127.0.0.1:3000`) and Electron concurrently. Electron launches after 3 seconds to allow Vite to initialize. BoxLang MiniServer starts automatically on `http://127.0.0.1:59700`.
+
+### Electron only (Vite already running)
+
+```bash
+npm run start
+```
+
+### Production build preview (no HMR)
+
+```bash
+npm run prod
+```
+
+Runs `vite build` then starts Electron using the compiled assets.
+
+### Vite-only asset preview
+
+```bash
+npm run preview
+```
+
+---
+
+## BoxLang MiniServer
+
+The app spawns a BoxLang MiniServer as a child process. In development it uses a globally installed `boxlang-miniserver`. For a packaged/distributable build you must bundle the MiniServer locally first.
+
+### Package the MiniServer for distribution
+
+```bash
+# Download and extract MiniServer into .miniserver/ (reads version from .bvmrc)
+npm run package:miniserver
+
+# Force re-download even if already packaged
+npm run package:miniserver:force
+```
+
+This downloads BoxLang MiniServer `1.6.0` and extracts it to `.miniserver/bin/` and `.miniserver/lib/`. The packaged app uses these binaries instead of the global installation.
+
+### Server configuration
+
+The server is configured in `.electron/Main.js` under `globalSettings`:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `serverPort` | `59700` | Local HTTP port |
+| `serverDebugMode` | `true` in dev, `false` in prod | BoxLang `--debug` flag |
+| `appName` | `"BoxLang Starter Desktop"` | Window title and tray tooltip |
+| `windowWidth` / `windowHeight` | `1200` / `800` | Initial window dimensions |
+
+BoxLang runtime settings (session timeout, datasources, caching, logging) live in `.boxlang/config/boxlang.json`.
+
+---
+
+## Building & Packaging
+
+### 1. Generate the Windows icon (first time only)
+
+Windows packaging requires `includes/icon.ico`. Generate it from the existing PNG assets:
+
+```bash
+npm run generate:icons
+```
+
+> Requires `png-to-ico` which is included as a dev dependency.
+
+### 2. Package the application
+
+```bash
+# Vite build + electron-builder (requires .miniserver/ to be populated first)
+npm run package
+
+# Full pipeline: package MiniServer, then build and package the app
+npm run package:full
+```
+
+Output goes to `dist/electron/`.
+
+| Platform | Output | Format |
+|----------|--------|--------|
+| macOS | `BoxLang Starter Desktop.dmg` | DMG |
+| Windows | `BoxLang Starter Desktop Setup.exe` | NSIS installer |
+| Linux | `boxlang-starter-electron-1.0.0.AppImage` | AppImage |
+
+### Platform notes
+
+**macOS** — Requires `includes/icon.icns`. No code signing is configured by default; for distribution outside the App Store you will need to add `mac.identity` and set up notarization in `package.json`.
+
+**Windows** — Requires `includes/icon.ico` (generate with `npm run generate:icons`). The NSIS installer is non-silent with desktop and start menu shortcuts.
+
+**Linux** — AppImage with category `Utility`. Runs on most distributions without installation.
+
+---
+
+## OS Integration
+
+The app integrates with each OS's native desktop environment:
+
+### System Tray (all platforms)
+- Tray icon persists when the window is closed/hidden
+- Context menu: Show, Restart Server, Open in Browser, Quit
+- Single-click the tray icon to toggle the window
+
+### Window close behavior
+- **macOS** — closing the window hides it (Cmd+Q or File → Quit to exit)
+- **Windows / Linux** — closing the window hides it to tray (requires tray icon); if tray fails, window closes normally
+
+### macOS Dock
+- App icon set from `includes/icon.icns`
+- Dock badge shows `…` while the server is starting, cleared when ready
+- Clicking the dock icon re-shows the window if it was hidden
+
+### Windows Taskbar
+- Overlay icon shown on the taskbar button
+- Progress bar is shown (indeterminate) while the server starts
+
+### Desktop Notifications
+Fired automatically at key lifecycle events:
+
+| Event | Notification |
+|-------|-------------|
+| Server started | "BoxLang Server Started — port 59700" |
+| Server crashed | "BoxLang Server Crashed — restarting in 5s" |
+| Manual restart | "BoxLang Server — Restarting server…" |
+
+### Global Keyboard Shortcuts
+These work system-wide (even when the app window is not focused):
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl + Shift + L` | Show / hide window |
+| `Cmd/Ctrl + Shift + R` | Restart BoxLang server |
+| `Cmd/Ctrl + Shift + O` | Open app in default browser |
+
+---
+
+## Asset Pipeline
+
+Vite processes `resources/assets/` and outputs hashed files to `includes/resources/`. BoxLang templates use `ViteHelper.bx` to resolve the correct URLs in both development and production.
+
+### Adding assets in BoxLang templates
+
+```html
+<bx:script>
+    viteHelper = application.viteHelper; // initialized in Application.bx
+</bx:script>
+
+<!-- CSS -->
+<bx:output>#viteHelper.styles( "styles" )#</bx:output>
+
+<!-- JavaScript -->
+<bx:output>#viteHelper.scripts( "app" )#</bx:output>
+```
+
+In development, `ViteHelper` points to the Vite HMR server (`http://127.0.0.1:3000`). In production, it reads `includes/resources/.vite/manifest.json` and outputs the hashed filenames.
+
+### Adding JavaScript
+
+Place files under `resources/assets/js/`. Import them from `app.js`:
 
 ```javascript
 // resources/assets/js/app.js
 import '../scss/app.scss';
-// Your JavaScript code here
+import Alpine from 'alpinejs';
+Alpine.start();
 ```
 
-### Stylesheets
+### Adding SCSS
 
-Place your SCSS files in `resources/assets/scss/`. The main entry point is `app.scss`.
+Place partials under `resources/assets/scss/` and import them in `app.scss`. The starter includes a design system with CSS variables, a 12-column grid, buttons, forms, and cards.
 
-```scss
-// resources/assets/scss/app.scss
-// Your styles here
-```
-
-### Using Assets in BoxLang Templates
-
-The `ViteHelper.bx` component provides methods to include Vite-processed assets:
-
-```boxlang
-<bx:script>
-    viteHelper = new includes.helpers.ViteHelper();
-</bx:script>
-
-<!-- Include CSS -->
-<bx:output>#viteHelper.styles( "styles" )#</bx:output>
-
-<!-- Include JavaScript -->
-<bx:output>#viteHelper.scripts( "app" )#</bx:output>
-```
-
-## Configuration
-
-### Vite Configuration
-
-Edit `vite.config.js` to customize:
-- Asset processing
-- Development server settings
-- Build output configuration
-
-### Electron Configuration
-
-Edit `electron/main.js` to customize:
-- Window properties
-- BoxLang server settings
-- Application behavior
-
-### BoxLang Configuration
-
-Edit `config/boxlang.json` for BoxLang-specific settings.
+---
 
 ## Available Scripts
 
 | Script | Description |
 |--------|-------------|
-| `npm run dev` | Start Vite dev server |
-| `npm run build` | Build assets for production |
-| `npm run preview` | Preview production build |
-| `npm run dev:electron` | Start both Vite and Electron |
-| `npm run start` | Start Electron app |
-| `npm run package` | Package the application |
-| `npm run make` | Create distributable packages |
+| `npm run dev` | Start Vite + Electron in development mode |
+| `npm run start` | Start Electron only (Vite must already be running) |
+| `npm run build` | Vite production build |
+| `npm run prod` | Vite build + start Electron |
+| `npm run preview` | Preview Vite build in browser |
+| `npm run package` | Vite build + electron-builder |
+| `npm run package:miniserver` | Download and package BoxLang MiniServer |
+| `npm run package:miniserver:force` | Force re-download MiniServer |
+| `npm run package:full` | Package MiniServer + build + electron-builder |
+| `npm run generate:icons` | Generate `includes/icon.ico` for Windows |
+| `npm run lint` | Run ESLint |
+| `npm run lint:fix` | Run ESLint with auto-fix |
 
-## Development Helper Script
+---
 
-The included `dev.sh` script provides convenient commands:
+## Configuration Reference
 
-```bash
-./dev.sh dev      # Start development mode
-./dev.sh build    # Build assets
-./dev.sh package  # Package application
-./dev.sh clean    # Clean build artifacts
-./dev.sh install  # Install dependencies
+### `.electron/Main.js` — `globalSettings`
+
+The central configuration object. Edit this to change app-level behavior:
+
+```js
+const globalSettings = {
+    serverPort: 59700,         // MiniServer port
+    serverDebugMode: true,     // --debug flag (auto-false in production)
+    appName: "BoxLang Starter Desktop",
+    windowHeight: 800,
+    windowWidth: 1200,
+};
 ```
 
-## Environment Variables
+### `.boxlang/config/boxlang.json`
 
-You can set these environment variables to customize behavior:
+BoxLang runtime settings: session management, datasources, caching, logging, security restrictions, and module paths. See the [BoxLang documentation](https://boxlang.ortusbooks.com) for all available options.
 
-- `ENVIRONMENT` - Set to "development" or "production"
-- `VITE_HOST` - Vite dev server host (default: 127.0.0.1:3000)
-- `VITE_PROTOCOL` - Protocol for dev server (default: http)
+### `vite.config.mjs`
 
-## Tips & Best Practices
+- Dev server: `http://127.0.0.1:3000`
+- Build output: `includes/resources/`
+- Entry points: `resources/assets/js/app.js`, `resources/assets/scss/app.scss`
 
-1. **Development Workflow**
-   - Use `npm run dev:electron` for the best development experience
-   - The Vite dev server provides hot module replacement
-   - BoxLang changes require a server restart
+### `package.json` — `build` (electron-builder)
 
-2. **Asset Organization**
-   - Keep related JavaScript files together
-   - Use SCSS partials for better organization
-   - Import all dependencies in your main entry files
+The `build` key controls the electron-builder configuration. Key options:
 
-3. **Production Builds**
-   - Always run `npm run build` before packaging
-   - Test the production build with `npm run preview`
-   - Assets are automatically optimized and hashed
+```json
+{
+  "build": {
+    "appId": "io.boxlang.starter",
+    "asar": true,
+    "asarUnpack": [".miniserver/**"],
+    "nsis": { "oneClick": false, "createDesktopShortcut": true },
+    "linux": { "category": "Utility" }
+  }
+}
+```
 
-4. **Cross-Platform Considerations**
-   - Test on all target platforms
-   - Use appropriate icons for each platform
-   - Consider platform-specific features
+> `asarUnpack` is required for `.miniserver/` — JVM executables cannot run from inside an asar archive.
+
+---
 
 ## Troubleshooting
 
-### Common Issues
+### BoxLang server won't start
 
-1. **Assets not loading in production**
-   - Ensure `npm run build` was run before packaging
-   - Check that the manifest file is being generated
+- **Global install path issue** — the app adds `/usr/local/bin` to `PATH` automatically, but if your BoxLang installation is elsewhere, run: `export PATH="/your/boxlang/bin:$PATH"` before starting the app
+- **Port already in use** — change `serverPort` in `globalSettings` and ensure no other process is using the port
+- **Packaged miniserver missing** — run `npm run package:miniserver` to download it
 
-2. **Vite dev server not starting**
-   - Check if port 3000 is available
-   - Verify all dependencies are installed
+### Tray icon not appearing
 
-3. **BoxLang server errors**
-   - Check BoxLang MiniServer is installed and in PATH
-   - Verify BoxLang configuration in `config/boxlang.json`
+- Ensure `includes/icon.iconset/icon_16x16.png` exists
+- On some Linux desktops (GNOME), system tray requires a shell extension (e.g. *AppIndicator Support*)
 
-### Getting Help
+### Assets not loading in production
 
-- Check the console for error messages
-- Review the Electron developer tools
-- Examine the Vite build output
+- Run `npm run build` before `npm run package` — the Vite manifest must exist in `includes/resources/.vite/manifest.json`
+- Make sure `resources/assets/` is excluded from electron-builder (source files should not be packaged)
+
+### Windows installer fails (missing icon)
+
+- Run `npm run generate:icons` to create `includes/icon.ico` before packaging
+
+### DevTools open on every launch
+
+- Only in `NODE_ENV=development` — DevTools are disabled in packaged production builds
+
+---
 
 ## License
 
-This starter template is provided as-is for educational and development purposes.
+Apache-2.0 — see [LICENSE](LICENSE) for details.
+
+Built with [BoxLang](https://www.boxlang.io) by [Ortus Solutions](https://www.ortussolutions.com).


### PR DESCRIPTION
Previous README had wrong file paths (electron/main.js, config/boxlang.json), referenced nonexistent scripts (dev:electron, make, dev.sh), and documented none of the actual architecture.

New README covers:
- Accurate project structure with all .electron/ modules explained
- Correct npm scripts (dev, start, prod, package, package:full, generate:icons, etc.)
- BoxLang MiniServer setup and packaging workflow
- Packaging guide for macOS (DMG), Windows (NSIS), Linux (AppImage)
- OS integration: system tray, close-to-tray, dock badge, taskbar progress, desktop notifications, global keyboard shortcuts
- Vite asset pipeline and ViteHelper usage in BoxLang templates
- Configuration reference for globalSettings, boxlang.json, vite.config.mjs, and electron-builder (including asarUnpack requirement)
- Troubleshooting section for common issues

https://claude.ai/code/session_01MLpZyf65DVwfi36susXmsp