### PR TITLE
feat: set BOXLANG_HOME env variable on miniserver start for DCA packaging

### DIFF
--- a/.electron/BoxLang.js
+++ b/.electron/BoxLang.js
@@ -175,7 +175,7 @@ export class BoxLang {
             detached: false,
             shell: false,
             windowsHide: true,
-            env: { ...process.env }
+            env: { ...process.env, BOXLANG_HOME: path.join( projectRoot, '.miniserver', 'home' ) }
         };
 
         // For packaged miniserver, we need to set up the environment

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ WEB-INF
 .boxlang/config/.seed
 
 # MiniServer runtime home (logs, compiled classes, etc.)
-.miniserver/.boxlang/
+.miniserver/home/
 
 # Engines + Database + CBFS + Secrets
 .env

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ All BoxLang MiniServer settings live in `miniserver.json` at the project root:
 | `port` | `59700` | Local HTTP port |
 | `host` | `127.0.0.1` | Bind address (localhost only) |
 | `webroot` | `.` | Web root directory |
-| `serverHome` | `.miniserver/.boxlang` | BoxLang runtime data directory |
+| `serverHome` | `.miniserver/home` | BoxLang runtime data directory |
 | `rewrites` | `true` | Enable URL rewriting |
 | `debug` | `false` | Enable debug/verbose output |
 

--- a/miniserver.json
+++ b/miniserver.json
@@ -10,7 +10,7 @@
 "webroot": ".",
 // Where BoxLang stores its runtime files (logs, compiled classes, etc.)
 // Kept inside .miniserver so the whole runtime package is self-contained
-"serverHome": ".miniserver/.boxlang",
+"serverHome": ".miniserver/home",
 // Enable URL rewriting support
 "rewrites": true,
 // Enable debug/verbose output — set to true for local debugging

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 			"!**/node_modules/**",
 			"!dist/electron/**",
 			"!resources/assets/**",
-			"!.miniserver/.boxlang/**",
+			"!.miniserver/home/**",
 			"!.boxlang/classes/**",
 			"!.boxlang/logs/**"
 		],


### PR DESCRIPTION
Sets BOXLANG_HOME to projectRoot/.miniserver/home in the miniserver spawn
environment so BoxLang uses the app bundle directory as its home when
packaged as a DCA via electron-builder, rather than defaulting to a
system path.

Also renames the BoxLang home path from .miniserver/.boxlang to
.miniserver/home across miniserver.json, .gitignore, package.json
build exclusions, and README docs for consistency.

https://claude.ai/code/session_01PLeeMRBB4TPgLALuEomPKC