### PR TITLE
Fix startup options for windows

### DIFF
--- a/app/electron/BoxLang.js
+++ b/app/electron/BoxLang.js
@@ -293,7 +293,7 @@ export class BoxLang {
         const spawnOptions = {
             cwd: this.globalSettings.projectRoot,
             detached: false,
-            shell: false,
+            shell: process.platform === 'win32',
             windowsHide: true,
             env: {
                 ...process.env,


### PR DESCRIPTION
Fix windows 'spawn EINVAL' error when starting on windows

Example of error:
```
[2026-05-01T12:51:58.212Z] [ERROR] Unhandled rejection spawn EINVAL
Error: spawn EINVAL
    at ChildProcess.spawn (node:internal/child_process:420:11)
    at spawn (node:child_process:800:9)
    at BoxLang.start (file:///boxlang-starter-desktop-electron/app/electron/BoxLang.js:320:24)
    at file:///boxlang-starter-desktop-electron/app/electron/Main.js:181:13
```

This routes the spawn call through `cmd.exe` on Windows, which correctly handles `.bat` file execution. The behavior on macOS and Linux is completely unchanged (`shell: false`).